### PR TITLE
Add Typography component and related styles; refactor Dialog to use T…

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from "react";
 import { useDialog, useModal, useOverlay, usePreventScroll } from "react-aria";
 import { Button } from "../button/Button";
+import { Typography } from "../typography/Typography";
 import styles from "./index.module.css";
 
 type DialogProps = {
@@ -38,12 +39,14 @@ export const Dialog: React.FC<DialogProps> = ({
         ref={ref}
         className={styles.container}
       >
-        <h1 {...titleProps} className={styles.title}>
+        <Typography as="h1" size="lg" {...titleProps}>
           {title}
-        </h1>
+        </Typography>
         <div className={styles.content}>
-          <p>{date}</p>
-          <p>{text}</p>
+          <Typography>
+            {`${date}
+            ${text}`}
+          </Typography>
         </div>
         <DialogButtons onClose={onClose} onConfirm={onConfirm} />
       </div>

--- a/src/components/type.ts
+++ b/src/components/type.ts
@@ -1,0 +1,2 @@
+export type Size = "xs" | "sm" | "md" | "lg" | "xl";
+export type Variant = "primary" | "secondary" | "accent" | "background";

--- a/src/components/typography/Typography.tsx
+++ b/src/components/typography/Typography.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import type { Size, Variant } from "../type";
+
+type AsElement = "p" | "span" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+type TypographyProps = React.HTMLAttributes<HTMLElement> & {
+  children: React.ReactNode;
+  size?: Size;
+  variant?: Variant;
+  bold?: boolean;
+  as?: AsElement;
+};
+
+const sizeMap = {
+  xs: "var(--font-size-xs)",
+  sm: "var(--font-size-sm)",
+  md: "var(--font-size-md)",
+  lg: "var(--font-size-lg)",
+  xl: "var(--font-size-xl)",
+};
+
+const colorMap = {
+  primary: "var(--color-primary)",
+  secondary: "var(--color-secondary)",
+  accent: "var(--color-accent)",
+  background: "var(--color-background)",
+};
+
+const headingSizeMap: Record<AsElement, Size> = {
+  h1: "xl",
+  h2: "lg",
+  h3: "md",
+  h4: "sm",
+  h5: "xs",
+  h6: "xs",
+  p: "md",
+  span: "md",
+};
+
+export const Typography: React.FC<TypographyProps> = ({
+  children,
+  size,
+  variant,
+  bold = false,
+  as = "p",
+  ...restProps
+}) => {
+  const Component = as;
+
+  const resolvedSizeKey = size ?? headingSizeMap[as] ?? "md";
+  const resolvedSize = sizeMap[resolvedSizeKey];
+
+  const style: React.CSSProperties = {
+    fontSize: resolvedSize,
+    color: variant ? colorMap[variant] : "black",
+    fontWeight: bold ? "bold" : "normal",
+    whiteSpace: "pre-wrap",
+  };
+
+  return (
+    <Component style={style} {...restProps}>
+      {children}
+    </Component>
+  );
+};

--- a/src/components/typography/index.module.css
+++ b/src/components/typography/index.module.css
@@ -1,0 +1,3 @@
+.typography {
+  @apply leading-relaxed break-words;
+}

--- a/src/global.css
+++ b/src/global.css
@@ -13,7 +13,9 @@
 
   --font-sans: "Noto Sans Japanese";
 
-  --font-size-lg: 2rem;
-  --font-size-md: 1rem;
+  --font-size-xs: 0.5rem;
   --font-size-sm: 0.75rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.5rem;
+  --font-size-xl: 2rem;
 }

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -1,0 +1,80 @@
+import type { Size, Variant } from "@/components/type";
+import { Typography } from "@/components/typography/Typography";
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Typography> = {
+  title: "Components/Typography",
+  component: Typography,
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["xs", "sm", "md", "lg", "xl"] satisfies Size[],
+    },
+    variant: {
+      control: "select",
+      options: [
+        "primary",
+        "secondary",
+        "accent",
+        "background",
+      ] satisfies Variant[],
+    },
+    bold: { control: "boolean" },
+    as: {
+      control: "select",
+      options: ["p", "span", "h1", "h2", "h3", "h4", "h5", "h6"],
+    },
+    children: {
+      control: "text",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Typography>;
+
+export const Default: Story = {
+  args: {
+    children: "これはデフォルトのテキストです。",
+    size: "md",
+    variant: "primary",
+    bold: false,
+    as: "p",
+  },
+};
+
+export const Bold: Story = {
+  args: {
+    children: "太字のテキストです。",
+    size: "lg",
+    bold: true,
+    variant: "secondary",
+  },
+};
+
+export const AccentSmall: Story = {
+  args: {
+    children: "小さいアクセントカラーのテキスト。",
+    size: "sm",
+    variant: "accent",
+  },
+};
+
+export const BackgroundSpan: Story = {
+  args: {
+    children: "span要素で表示されるテキスト。",
+    as: "span",
+    size: "xl",
+    variant: "background",
+    bold: true,
+  },
+};
+
+export const HeadingDefaultSize: Story = {
+  args: {
+    children: "これは h1 見出し (size 未指定)",
+    as: "h1",
+    variant: "primary",
+  },
+};


### PR DESCRIPTION
This pull request introduces a new reusable `Typography` component to standardize text rendering and styling across the application. It refactors the dialog UI to use this component, adds supporting types, updates global font size variables, and provides Storybook stories for documentation and testing.

**Typography Component Implementation and Integration**

* Added a new `Typography` component (`src/components/typography/Typography.tsx`) that supports configurable element type, size, color variant, and boldness for consistent text styling.
* Refactored the `Dialog` component (`src/components/dialog/Dialog.tsx`) to use the `Typography` component for both the title and content, replacing direct usage of HTML tags. [[1]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0R4) [[2]](diffhunk://#diff-c0a070a5b452b1898fdf22039ab69180fcc7a4bda599fe07b124eacf31d35af0L41-R49)

**Supporting Types and Styles**

* Introduced shared `Size` and `Variant` types in `src/components/type.ts` to define allowed values for typography props.
* Added a CSS module for typography styles with utility classes for improved text layout (`src/components/typography/index.module.css`).

**Global Theme and Storybook Documentation**

* Updated global font size variables in `src/global.css` to support the new sizing options used by `Typography`.
* Added comprehensive Storybook stories for the `Typography` component to showcase its variants and usage (`src/stories/Typography.stories.tsx`).